### PR TITLE
Replaced template name collision detection algorithm with a hash table

### DIFF
--- a/libxslt/imports.c
+++ b/libxslt/imports.c
@@ -400,19 +400,12 @@ xsltFindTemplate(xsltTransformContextPtr ctxt, const xmlChar *name,
 	return(NULL);
     style = ctxt->style;
     while (style != NULL) {
-	cur = style->templates;
-	while (cur != NULL) {
-	    if (xmlStrEqual(name, cur->name)) {
-		if (((nameURI == NULL) && (cur->nameURI == NULL)) ||
-		    ((nameURI != NULL) && (cur->nameURI != NULL) &&
-		     (xmlStrEqual(nameURI, cur->nameURI)))) {
-		    return(cur);
-		}
-	    }
-	    cur = cur->next;
-	}
-
-	style = xsltNextImport(style);
+        if(style->namedTemplatesHash != NULL){
+            cur = (xsltTemplatePtr) xmlHashLookup2(style->namedTemplatesHash, name, nameURI);
+            if(cur != NULL)
+                return (cur);
+        }
+        style = xsltNextImport(style);
     }
     return(NULL);
 }

--- a/libxslt/pattern.c
+++ b/libxslt/pattern.c
@@ -2090,7 +2090,22 @@ xsltAddTemplate(xsltStylesheetPtr style, xsltTemplatePtr cur,
     const xmlChar *name = NULL;
     float priority;              /* the priority */
 
-    if ((style == NULL) || (cur == NULL) || (cur->match == NULL))
+    if ((style == NULL) || (cur == NULL))
+	return(-1);
+
+    /* register named template for future error validation */
+    if (cur->name != NULL && cur->nameURI != NULL){
+        if (style->namedTemplatesHash == NULL ){
+            style->namedTemplatesHash = xmlHashCreate(8);
+        }
+        if (style->namedTemplatesHash == NULL){
+            xmlGenericError(NULL, "malloc failed !\n");
+            return (-1);
+        }
+        xmlHashAddEntry2(style->namedTemplatesHash, cur->name, cur->nameURI, cur);
+    }
+
+    if (cur->match == NULL)
 	return(-1);
 
     priority = cur->priority;

--- a/libxslt/xslt.c
+++ b/libxslt/xslt.c
@@ -5147,7 +5147,6 @@ static int
 xsltHasNamedTemplate(xsltStylesheetPtr style,
                     const xmlChar * name,
                     const xmlChar * URI){
-
     if(style->namedTemplatesHash != NULL){
         xsltTemplatePtr list = (xsltTemplatePtr)
                 xmlHashLookup2(style->namedTemplatesHash, name, URI);
@@ -5437,15 +5436,6 @@ xsltParseStylesheetTemplate(xsltStylesheetPtr style, xmlNodePtr template) {
              goto error;
         }
 	}
-    /* register named template for future error validation */
-    if(style->namedTemplatesHash == NULL ){
-        style->namedTemplatesHash = xmlHashCreate(1024);
-    }
-    if(style->namedTemplatesHash == NULL){
-        xmlGenericError(NULL, "malloc failed !\n");
-        goto error;
-    }
-    xmlHashAddEntry2(style->namedTemplatesHash, ret->name, ret->nameURI, template);
 
     }
 

--- a/libxslt/xsltInternals.h
+++ b/libxslt/xsltInternals.h
@@ -1639,6 +1639,7 @@ struct _xsltStylesheet {
      * Forwards-compatible processing
      */
     int forwards_compatible;
+    void *namedTemplatesHash;	/* hash table on named templates */
 };
 
 typedef struct _xsltTransformCache xsltTransformCache;

--- a/tests/REC/test-6.1.err
+++ b/tests/REC/test-6.1.err
@@ -1,0 +1,2 @@
+compilation error: file test-6.1.xsl line 11 element template
+xsl:template: error duplicate name 'duplicateTemplateName'

--- a/tests/REC/test-6.1.xsl
+++ b/tests/REC/test-6.1.xsl
@@ -1,0 +1,14 @@
+<xsl:stylesheet version="1.0"
+      xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<!-- reject this XSLT named templates should have unique template name + nameURI combinations -->
+
+<xsl:template match="doc">
+    <xsl:call-template name="duplicateTemplateName"/>
+</xsl:template>
+<xsl:template name="duplicateTemplateName">
+<xsl:text>XSLT should be rejected</xsl:text>
+</xsl:template>
+<xsl:template name="duplicateTemplateName">
+<xsl:text>XSLT should be rejected</xsl:text>
+</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Replaced template name collision detection algorithm with a hash table look up. For big XSLTs (10000+ templates) this results in a huge improvement of the compilation time (~factor 20).

I tried to follow the style and use sensible locations for the new code. Please let me know if i got something wrong.