### PR TITLE
Xmlspace

### DIFF
--- a/libxslt/imports.c
+++ b/libxslt/imports.c
@@ -341,10 +341,14 @@ xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt, xmlNodePtr node) {
     xsltStylesheetPtr style;
     const xmlChar *val;
 
-    if ((ctxt == NULL) || (node == NULL))
+    if ((ctxt == NULL) || (ctxt->style == NULL) || (node == NULL))
+	return(0);
+    if ((node->type != XML_ELEMENT_NODE) || (xmlNodeGetSpacePreserve(node) == 1))
 	return(0);
     style = ctxt->style;
-    while (style != NULL) {
+    do {
+	if (style->stripSpaces == NULL)
+	    continue;
 	if (node->ns != NULL) {
 	    val = (const xmlChar *)
 	      xmlHashLookup2(style->stripSpaces, node->name, node->ns->href);
@@ -368,8 +372,7 @@ xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt, xmlNodePtr node) {
 	if (style->stripAll == -1)
 	    return(0);
 
-	style = xsltNextImport(style);
-    }
+    } while ((style = xsltNextImport(style)) != NULL);
     return(0);
 }
 

--- a/libxslt/transform.c
+++ b/libxslt/transform.c
@@ -4959,36 +4959,15 @@ xsltApplyTemplates(xsltTransformContextPtr ctxt, xmlNodePtr node,
 	    cur = NULL;
 	while (cur != NULL) {
 	    switch (cur->type) {
+#if 0 // Space stripping handled at document load
 		case XML_TEXT_NODE:
 		    if ((IS_BLANK_NODE(cur)) &&
-			(cur->parent != NULL) &&
-			(cur->parent->type == XML_ELEMENT_NODE) &&
-			(ctxt->style->stripSpaces != NULL)) {
-			const xmlChar *val;
-
-			if (cur->parent->ns != NULL) {
-			    val = (const xmlChar *)
-				  xmlHashLookup2(ctxt->style->stripSpaces,
-						 cur->parent->name,
-						 cur->parent->ns->href);
-			    if (val == NULL) {
-				val = (const xmlChar *)
-				  xmlHashLookup2(ctxt->style->stripSpaces,
-						 BAD_CAST "*",
-						 cur->parent->ns->href);
-			    }
-			} else {
-			    val = (const xmlChar *)
-				  xmlHashLookup2(ctxt->style->stripSpaces,
-						 cur->parent->name, NULL);
-			}
-			if ((val != NULL) &&
-			    (xmlStrEqual(val, (xmlChar *) "strip"))) {
-			    delNode = cur;
-			    break;
-			}
+			(xsltFindElemSpaceHandling(ctxt, cur->parent))) {
+			delNode = cur;
+			break;
 		    }
 		    /* no break on purpose */
+#endif
 		case XML_ELEMENT_NODE:
 		case XML_DOCUMENT_NODE:
 		case XML_HTML_DOCUMENT_NODE:


### PR DESCRIPTION
`xml:space="preserve"` in the source document should prevent space stripping due to `xsl:strip-space` during a transformation.

The XSLT specification states:
>A text node is preserved if any of the following apply:
>[...]
>An ancestor element of the text node has an xml:space attribute with a value of preserve, and no closer ancestor element has xml:space with a value of default. 

This change brings the space handling behavior of the `libxslt` into line with the specification.

This should also fix the following bugs:
https://bugzilla.gnome.org/show_bug.cgi?id=377433
https://bugzilla.gnome.org/show_bug.cgi?id=602918
