### PR TITLE
Check whether glibtoolize is available in addition to libtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,6 +8,15 @@ THEDIR=`pwd`
 cd $srcdir
 DIE=0
 
+case "$(uname)" in
+	Darwin)
+		LIBTOOLIZE=${LIBTOOLIZE:-glibtoolize}
+		;;
+	*)
+		LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}
+		;;
+esac
+
 (autoconf --version) < /dev/null > /dev/null 2>&1 || {
 	echo
 	echo "You must have autoconf installed to compile libxslt."
@@ -16,7 +25,7 @@ DIE=0
 	DIE=1
 }
 
-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
+($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 || {
 	echo
 	echo "You must have libtool installed to compile libxslt."
 	echo "Download the appropriate package for your distribution,"


### PR DESCRIPTION
macOS doesn't have libtoolize and GNU libtool only installs glibtoolize.